### PR TITLE
Fixed north access with only Rainstone and Sword of Kings

### DIFF
--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -38,7 +38,7 @@ end
 
 function paramina_rift()
     return Tracker:ProviderCountForCode('access_key') >= 2 or
-        (ozmone_plain() and Tracker:ProviderCountForCode('lentes_tear'))
+        (ozmone_plain() and Tracker:ProviderCountForCode('lentes_tear') > 0)
 end
 
 function defeat_bergan()


### PR DESCRIPTION
Adding > 0 to Lente's Tear in Paramina Rift fixes North access being available with only Rainstone and Sword of Kings