### PR TITLE
Removed scaled_difficulty from Draklor Laboratory as it was overruling the scaling_difficulty in locations.json

### DIFF
--- a/locations/draklor_laboratory.json
+++ b/locations/draklor_laboratory.json
@@ -7,8 +7,8 @@
         "map_locations": [
           {
             "map": "draklor_laboratory",
-            "x": 250,
-            "y": 890
+            "x": 310,
+            "y": 560
           }
         ],
         "sections": [

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -91,8 +91,7 @@ function sochen_cave_palace()
 end
 
 function draklor_laboratory()
-    return (Tracker:ProviderCountForCode('pw_chop') >= 3 or Tracker:ProviderCountForCode('sw_chop') > 0) and archades() and
-        scaled_difficulty(5)
+    return (Tracker:ProviderCountForCode('pw_chop') >= 3 or Tracker:ProviderCountForCode('sw_chop') > 0) and archades()
 end
 
 function has_n_chops(n)


### PR DESCRIPTION
The scaled_difficulty in the draklor_laboratory() function was overruling the scaled_difficulty for the individual checking set in locations.json. Removing it from logic.lua fixes this.
It also allows those checks to show up in out-of-scaling-logic yellow.