### PR TITLE
Updates location.json and logic.lua with AccessibilityLevel.SequenceBreak fixes

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -4268,7 +4268,7 @@
       {
         "name": "Archades",
         "access_rules": [
-          "^^$archades"
+          "^$archades"
         ],
         "sections": [
           {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -4140,7 +4140,7 @@
       {
         "name": "Draklor Laboratory",
         "access_rules": [
-          "$draklor_laboratory"
+          "^$draklor_laboratory"
         ],
         "sections": [
           {
@@ -4268,7 +4268,7 @@
       {
         "name": "Archades",
         "access_rules": [
-          "$archades"
+          "^^$archades"
         ],
         "sections": [
           {
@@ -7629,7 +7629,7 @@
       {
         "name": "Old Archades",
         "access_rules": [
-          "$archades"
+          "^^$archades"
         ],
         "sections": [
           {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -7629,7 +7629,7 @@
       {
         "name": "Old Archades",
         "access_rules": [
-          "^^$archades"
+          "^$archades"
         ],
         "sections": [
           {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -48,7 +48,7 @@
           {
             "name": "Windvane",
             "access_rules": [
-              "wind_globe,$defeat_vossler,[$scaled_difficulty|1]"
+              "wind_globe,^$defeat_vossler,[$scaled_difficulty|1]"
             ]
           },
           {
@@ -90,7 +90,7 @@
           {
             "name": "Grimy Fragment",
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|5]"
+              "^$tchita_uplands,[$scaled_difficulty|5]"
             ]
           }
         ]
@@ -2921,13 +2921,13 @@
           {
             "name": "Great-chief Elder After Defeating Vossler",
             "access_rules": [
-              "$defeat_vossler,$dawn_shard,[$scaled_difficulty|2]"
+              "^$defeat_vossler,$dawn_shard,[$scaled_difficulty|2]"
             ]
           },
           {
             "name": "Guest (Larsa)",
             "access_rules": [
-              "$defeat_vossler,$dawn_shard,[$scaled_difficulty|2]"
+              "^$defeat_vossler,$dawn_shard,[$scaled_difficulty|2]"
             ]
           },
           {
@@ -3264,7 +3264,7 @@
       {
         "name": "Tchita Uplands",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -4305,7 +4305,7 @@
               "place_hunts"
             ],
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|5]"
+              "^$tchita_uplands,[$scaled_difficulty|5]"
             ]
           },
           {
@@ -6484,19 +6484,19 @@
           {
             "name": "Dantro's Wife Give Cactus Flower",
             "access_rules": [
-              "cactus_flower,$defeat_vossler,[$scaled_difficulty|1]"
+              "cactus_flower,^$defeat_vossler,[$scaled_difficulty|1]"
             ]
           },
           {
             "name": "Cactus Family Quest",
             "access_rules": [
-              "cactus_flower,$defeat_vossler,[$scaled_difficulty|1]"
+              "cactus_flower,^$defeat_vossler,[$scaled_difficulty|1]"
             ]
           },
           {
             "name": "Patient Barheim Key",
             "access_rules": [
-              "cactus_flower,$defeat_vossler,[$scaled_difficulty|2]"
+              "cactus_flower,^$defeat_vossler,[$scaled_difficulty|2]"
             ]
           },
           {
@@ -6559,7 +6559,7 @@
       {
         "name": "Dalmasca Estersand North",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -6976,7 +6976,7 @@
               "place_hunts"
             ],
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|3]"
+              "^$tchita_uplands,[$scaled_difficulty|3]"
             ]
           },
           {
@@ -6985,7 +6985,7 @@
               "place_hunts"
             ],
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|6]"
+              "^$tchita_uplands,[$scaled_difficulty|6]"
             ]
           },
           {
@@ -6994,7 +6994,7 @@
               "place_hunts"
             ],
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|6]"
+              "^$tchita_uplands,[$scaled_difficulty|6]"
             ]
           },
           {
@@ -7003,13 +7003,13 @@
               "place_hunts"
             ],
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|6]"
+              "^$tchita_uplands,[$scaled_difficulty|6]"
             ]
           },
           {
             "name": "Jovy Reward",
             "access_rules": [
-              "clan_primer,$tchita_uplands,[$scaled_difficulty|7]"
+              "clan_primer,^$tchita_uplands,[$scaled_difficulty|7]"
             ]
           },
           {
@@ -7018,7 +7018,7 @@
               "place_hunts"
             ],
             "access_rules": [
-              "clan_primer,$tchita_uplands,[$scaled_difficulty|7]"
+              "clan_primer,^$tchita_uplands,[$scaled_difficulty|7]"
             ]
           }
         ]
@@ -7026,7 +7026,7 @@
       {
         "name": "Mosphoran Highwaste",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -7468,7 +7468,7 @@
       {
         "name": "Mosphoran Highwaste Upper",
         "access_rules": [
-          "$tchita_uplands,[$defeat_bergan]"
+          "^$tchita_uplands,[$defeat_bergan]"
         ],
         "sections": [
           {
@@ -7528,7 +7528,7 @@
       {
         "name": "Balfonheim",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -7638,13 +7638,13 @@
               "place_hunts"
             ],
             "access_rules": [
-              "rusted_scrap_of_armor,$tchita_uplands,[$scaled_difficulty|5]"
+              "rusted_scrap_of_armor,^$tchita_uplands,[$scaled_difficulty|5]"
             ]
           },
           {
             "name": "Moonsilver Medallion",
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|5]"
+              "^$tchita_uplands,[$scaled_difficulty|5]"
             ]
           },
           {
@@ -8107,7 +8107,7 @@
               "place_clan_boss"
             ],
             "access_rules": [
-              "$tchita_uplands,[$scaled_difficulty|5]"
+              "^$tchita_uplands,[$scaled_difficulty|5]"
             ]
           },
           {
@@ -8179,7 +8179,7 @@
               "place_clan_boss"
             ],
             "access_rules": [
-              "med_bravery,med_lusterless,$tchita_uplands,[$scaled_difficulty|7]"
+              "med_bravery,med_lusterless,^$tchita_uplands,[$scaled_difficulty|7]"
             ]
           },
           {
@@ -8188,7 +8188,7 @@
               "place_clan_boss"
             ],
             "access_rules": [
-              "med_love,med_lusterless,$tchita_uplands,[$scaled_difficulty|7]"
+              "med_love,med_lusterless,^$tchita_uplands,[$scaled_difficulty|7]"
             ]
           },
           {
@@ -8658,7 +8658,7 @@
           {
             "name": "Earth Tyrant Quest Wind Globe",
             "access_rules": [
-              "$defeat_vossler,[$scaled_difficulty|1]"
+              "^$defeat_vossler,[$scaled_difficulty|1]"
             ]
           },
           {
@@ -8701,7 +8701,7 @@
           {
             "name": "Dull Fragment",
             "access_rules": [
-              "sluice_gate_key,[$tchita_uplands,$scaled_difficulty|0]"
+              "sluice_gate_key,[^$tchita_uplands,$scaled_difficulty|0]"
             ]
           },
           {
@@ -9762,7 +9762,7 @@
       {
         "name": "Phon Coast",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -11684,7 +11684,7 @@
       {
         "name": "Cerobi Steppe",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -12644,7 +12644,7 @@
       {
         "name": "Nabreus Deadlands",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -13077,7 +13077,7 @@
       {
         "name": "Necrohol of Nabudis",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -15206,7 +15206,7 @@
       {
         "name": "Salikawood",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {
@@ -16339,7 +16339,7 @@
       {
         "name": "Sochen Cave Palace S",
         "access_rules": [
-          "$tchita_uplands"
+          "^$tchita_uplands"
         ],
         "sections": [
           {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "game_name": "FFXII",
   "package_version": "0.2.3",
   "package_uid": "ffxii_open_world_ap",
-  "author": "jeeves833, nouv, silasary, and Quinian",
+  "author": "jeeves833, nouv, silasary, Quinian and Rubik",
   "variants": {
     "standard": {
       "display_name": "Map Tracker",

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -99,14 +99,18 @@ function archades()
     if Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace() == AccessibilityLevel.SequenceBreak then
 		return AccessibilityLevel.SequenceBreak
 	end
-    return aero('arc_aero') or (Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace())
+    if aero('arc_aero') or (Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace()) then
+        return AccessibilityLevel.Normal
+    end
 end
 
 function sochen_cave_palace()
     if Tracker:ProviderCountForCode('soul_ward_key') > 0 and tchita_uplands() == AccessibilityLevel.SequenceBreak then
 		return AccessibilityLevel.SequenceBreak
 	end
-    return Tracker:ProviderCountForCode('soul_ward_key') > 0 and (tchita_uplands() or archades())
+    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and (tchita_uplands() or archades()) then
+        return AccessibilityLevel.Normal
+    end
 end
 
 function draklor_laboratory()

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -96,15 +96,27 @@ function dawn_shard()
 end
 
 function archades()
+    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace() == AccessibilityLevel.SequenceBreak then
+		return AccessibilityLevel.SequenceBreak
+	end
     return aero('arc_aero') or (Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace())
 end
 
 function sochen_cave_palace()
+    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and tchita_uplands() == AccessibilityLevel.SequenceBreak then
+		return AccessibilityLevel.SequenceBreak
+	end
     return Tracker:ProviderCountForCode('soul_ward_key') > 0 and (tchita_uplands() or archades())
 end
 
 function draklor_laboratory()
-    return (Tracker:ProviderCountForCode('pw_chop') >= 3 or Tracker:ProviderCountForCode('sw_chop') > 0) and archades()
+	if (Tracker:ProviderCountForCode('pw_chop') >= 3 or Tracker:ProviderCountForCode('sw_chop') > 0) then
+		if archades() == AccessibilityLevel.SequenceBreak then
+			return AccessibilityLevel.SequenceBreak
+		elseif archades() then
+			return AccessibilityLevel.Normal
+		end
+	end
 end
 
 function has_n_chops(n)

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -63,7 +63,7 @@ function ghis()
 end
 
 function sandseas()
-    if Tracker:ProviderCountForCode('access_key') > 0 or ghis() then
+    if Tracker:ProviderCountForCode('access_key') > 0 or ghis() or (Tracker:ProviderCountForCode('rainstone') > 0 and scaled_difficulty(3)) then
         return AccessibilityLevel.Normal
     end
     if Tracker:ProviderCountForCode('rainstone') > 0 then
@@ -72,8 +72,12 @@ function sandseas()
 end
 
 function tchita_uplands()
+    if (Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler() == AccessibilityLevel.SequenceBreak)  then
+		return AccessibilityLevel.SequenceBreak
+	end
     return defeat_bergan() or 
-        (Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler()) or earth_tyrant() or
+        (Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler() == AccessibilityLevel.Normal) or 
+        earth_tyrant() or
         (Tracker:ProviderCountForCode('soul_ward_key') > 0 and aero('arc_aero')) or
         cid2() or
         aero('bal_aero')


### PR DESCRIPTION
Locations in Mosphoran Highwaste, Salikawood, Phon Coast, and Archades with low difficulty scaling were being displayed as in-logic when defeat_vossler was returning out-of-logic. These changes update those locations and the logic scripts to more comprehensively handle AccessibilityLevel.SequenceBreak in those locations.

Updates sandseas-via-zertinan to be in-logic at the correct scaling

Also add myself to authors.