### PR TITLE
2x Location Corrections - White Mousse, Vossler

### DIFF
--- a/locations/garamsythe_waterway.json
+++ b/locations/garamsythe_waterway.json
@@ -207,7 +207,7 @@
         "map_locations": [
           {
             "map": "garamsythe_waterway",
-            "x": 935,
+            "x": 562,
             "y": 1100
           }
         ],

--- a/locations/tomb_of_king_raithwall.json
+++ b/locations/tomb_of_king_raithwall.json
@@ -127,7 +127,7 @@
         ]
       },
       {
-        "name": "Defeat Vossler",
+        "name": "Defeat Vossler - via the waystone",
         "map_locations": [
           {
             "map": "tomb_of_king_raithwall",
@@ -138,7 +138,7 @@
         "sections": [
           {
             "name": "Defeat Vossler - via the waystone",
-            "ref": "Main/Tomb of Raithwall/Defeat Vossler - via the waystone"
+            "ref": "Main/Tomb of Raithwall/Defeat Vossler"
           }
         ]
       },

--- a/locations/tomb_of_king_raithwall.json
+++ b/locations/tomb_of_king_raithwall.json
@@ -127,7 +127,7 @@
         ]
       },
       {
-        "name": "Defeat Vossler - via the waystone",
+        "name": "Defeat Vossler",
         "map_locations": [
           {
             "map": "tomb_of_king_raithwall",


### PR DESCRIPTION
Correction 1: the coordinates for the White Mousse hunt target on the Garamsythe Waterway map misplaced it in the East Sluice Control, whereas the White Mousse appears in West Sluice Control as specified in the clan primer hunt description + in-game map. X coordinate adjusted to 562, has been tested and refined.

Correction 2: "Defeat Vossler" location was properly registering on the overworld marker breakdown as one of the locations within Tomb of Raithwall, but no icon was appearing on the sub-map for Tomb of Raithwall itself. After looking it up in the JSON files it appeared to have an entry, but adjusting the coordinates did not make it appear. I was able to track down the issue to an extraneous bit of verbiage " - via the waystone" affixed to the name of the location in the REF line. I'm guessing this addendum was added to the visible label for clarity to guide people to the teleporter, so as part of a visible label it's definitely useful, but with it also included in the reference as well, it no longer matched and broke the location. Deleting the verbiage restored the icon to visibility.