### PR TITLE
Updates for more Sequence Break accesses

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -7489,7 +7489,8 @@
       {
         "name": "Balfonheim",
         "access_rules": [
-          "^$tchita_uplands,$aero|bal_aero"
+          "^$tchita_uplands,[$scaled_difficulty|5]",
+		      "$aero|bal_aero"
         ],
         "sections": [
           {

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -573,7 +573,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "nazarnir"
           }
@@ -1910,7 +1910,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "victanir"
           }
@@ -2153,7 +2153,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|6]"
+              "^$hunt_club_start,[$scaled_difficulty|6]"
             ],
             "hosted_item": "zombie_lord"
           }
@@ -2211,7 +2211,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "ishteen"
           },
@@ -3082,7 +3082,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,dawn_shard,[$scaled_difficulty|5]"
+              "^$hunt_club_start,dawn_shard,[$scaled_difficulty|5]"
             ],
             "hosted_item": "myath"
           },
@@ -4146,7 +4146,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "kris"
           },
@@ -4156,7 +4156,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "grimalkin"
           }
@@ -4555,7 +4555,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|5]"
+              "^$hunt_club_start,[$scaled_difficulty|5]"
             ],
             "hosted_item": "crystal_knight"
           },
@@ -5642,7 +5642,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,$has_n_black_orbs|3,[$scaled_difficulty|7]"
+              "^$hunt_club_start,$has_n_black_orbs|3,[$scaled_difficulty|7]"
             ],
             "hosted_item": "avenger"
           }
@@ -6475,7 +6475,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "terror_tyrant"
           },
@@ -6822,7 +6822,7 @@
               "place_hunts"
             ],
             "access_rules": [
-              "clan_primer,aero|bhu_aero,[$scaled_difficulty|1]"
+              "clan_primer,[$scaled_difficulty|1]"
             ]
           },
           {
@@ -7444,7 +7444,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "dheed"
           },
@@ -7489,7 +7489,7 @@
       {
         "name": "Balfonheim",
         "access_rules": [
-          "^$tchita_uplands"
+          "^$tchita_uplands,$aero|bal_aero"
         ],
         "sections": [
           {
@@ -8662,7 +8662,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|5]"
+              "^$hunt_club_start,[$scaled_difficulty|5]"
             ],
             "hosted_item": "kaiser_wolf"
           }
@@ -9055,7 +9055,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|6]"
+              "^$hunt_club_start,[$scaled_difficulty|6]"
             ],
             "hosted_item": "gavial"
           }
@@ -9531,7 +9531,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|6]"
+              "^$hunt_club_start,[$scaled_difficulty|6]"
             ],
             "hosted_item": "killbug"
           }
@@ -9690,7 +9690,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|6]"
+              "^$hunt_club_start,[$scaled_difficulty|6]"
             ],
             "hosted_item": "biding_mantis"
           },
@@ -10624,7 +10624,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "skullash"
           }
@@ -11168,7 +11168,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|5]"
+              "^$hunt_club_start,[$scaled_difficulty|5]"
             ],
             "hosted_item": "ancbolder"
           },
@@ -11628,7 +11628,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|5]"
+              "^$hunt_club_start,[$scaled_difficulty|5]"
             ],
             "hosted_item": "alteci"
           },
@@ -12657,7 +12657,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "bluesang"
           },
@@ -12667,7 +12667,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "aspidochelon"
           }
@@ -13100,7 +13100,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "arioch"
           }
@@ -13152,7 +13152,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "vorres"
           },
@@ -13597,7 +13597,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "melt"
           },
@@ -14707,7 +14707,7 @@
               "trophies"
             ],
             "access_rules": [
-              "site_3_key,site_11_key,$hunt_club_start,[$scaled_difficulty|7]"
+              "site_3_key,site_11_key,^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "disma"
           }
@@ -15229,7 +15229,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "bull_chocobo"
           }
@@ -15247,7 +15247,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|5]"
+              "^$hunt_club_start,[$scaled_difficulty|5]"
             ],
             "hosted_item": "rageclaw"
           }
@@ -15767,7 +15767,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "dreadguard"
           },
@@ -16508,7 +16508,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|5]"
+              "^$hunt_club_start,[$scaled_difficulty|5]"
             ],
             "hosted_item": "wendice"
           },
@@ -16518,7 +16518,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "anubys"
           },
@@ -17175,7 +17175,7 @@
               "trophies"
             ],
             "access_rules": [
-              "$hunt_club_start,[$scaled_difficulty|7]"
+              "^$hunt_club_start,[$scaled_difficulty|7]"
             ],
             "hosted_item": "abelisk"
           },

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -159,7 +159,7 @@ function cid2()
     local stoneCount = Tracker:ProviderCountForCode('goddess_magicite') + Tracker:ProviderCountForCode('nethicite') +
         Tracker:ProviderCountForCode('dawn_shard')
 
-    return swordCount >= 1 and stoneCount >= 2 and has_n_system_access_keys(2)
+    return swordCount >= 1 and stoneCount >= 2 and has_n_system_access_keys(2) and has_n_black_orbs(3)
 end
 
 function defeat_cid()

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -97,15 +97,16 @@ function tchita_uplands()
         earth_tyrant() == AccessibilityLevel.Normal or
         (Tracker:ProviderCountForCode('soul_ward_key') > 0 and aero('arc_aero') and scaled_difficulty(4)) or
         cid2() == AccessibilityLevel.Normal or
+		has_n_system_access_keys(3) or
         (aero('bal_aero') and scaled_difficulty(5)) then
 		    return AccessibilityLevel.Normal
     end
-    if (Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler() == AccessibilityLevel.SequenceBreak) or
-		(Tracker:ProviderCountForCode('soul_ward_key') > 0 and aero('arc_aero')) or
+    if defeat_bergan() == AccessibilityLevel.SequenceBreak  or
+		(Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler() == AccessibilityLevel.SequenceBreak) or
 		earth_tyrant() == AccessibilityLevel.SequenceBreak or
-		defeat_bergan() == AccessibilityLevel.SequenceBreak  or
+		(Tracker:ProviderCountForCode('soul_ward_key') > 0 and aero('arc_aero')) or
         cid2() == AccessibilityLevel.SequenceBreak or
-        aero('bal_aero') then 
+        aero('bal_aero') then
 			return AccessibilityLevel.SequenceBreak
 	end
 end

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -114,7 +114,7 @@ function hunt_club_start()
     if tchita_uplands() == AccessibilityLevel.Normal and Tracker:ProviderCountForCode('shelled_trophy') > 0 and scaled_difficulty(6) then
 		return AccessibilityLevel.Normal
 	end
-	if tchita_uplands() == AccessibilityLevel.SequenceBreak and Tracker:ProviderCountForCode('shelled_trophy') > 0 then
+	if tchita_uplands() and Tracker:ProviderCountForCode('shelled_trophy') > 0 then
 		return AccessibilityLevel.SequenceBreak
 	end
 end

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -30,7 +30,7 @@ function get_char_count()
         Tracker:ProviderCountForCode('penelo') + Tracker:ProviderCountForCode('guest')
 end
 
-function cerobi_access()
+function cerobi_access()	-- Why does this function exist?
     return tchita_uplands() or aero('bal_aero')
 end
 
@@ -54,7 +54,12 @@ function paramina_rift()
 end
 
 function defeat_bergan()
-    return paramina_rift() and Tracker:ProviderCountForCode('sword_of_kings') > 0 and scaled_difficulty(3)
+    if paramina_rift() and Tracker:ProviderCountForCode('sword_of_kings') > 0 and scaled_difficulty(3) then
+		return AccessibilityLevel.Normal
+	end
+	if paramina_rift() and Tracker:ProviderCountForCode('sword_of_kings') > 0 then
+		return AccessibilityLevel.SequenceBreak
+	end
 end
 
 function earth_tyrant()
@@ -87,19 +92,31 @@ function sandseas()
 end
 
 function tchita_uplands()
-    if (Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler() == AccessibilityLevel.SequenceBreak)  then
-		return AccessibilityLevel.SequenceBreak
-	end
-    return defeat_bergan() or 
+    if defeat_bergan() == AccessibilityLevel.Normal or 
         (Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler() == AccessibilityLevel.Normal) or 
-        earth_tyrant() or
-        (Tracker:ProviderCountForCode('soul_ward_key') > 0 and aero('arc_aero')) or
-        cid2() or
-        aero('bal_aero')
+        earth_tyrant() == AccessibilityLevel.Normal or
+        (Tracker:ProviderCountForCode('soul_ward_key') > 0 and aero('arc_aero') and scaled_difficulty(4)) or
+        cid2() == AccessibilityLevel.Normal or
+        (aero('bal_aero') and scaled_difficulty(5)) then
+		    return AccessibilityLevel.Normal
+    end
+    if (Tracker:ProviderCountForCode('cactus_flower') > 0 and defeat_vossler() == AccessibilityLevel.SequenceBreak) or
+		(Tracker:ProviderCountForCode('soul_ward_key') > 0 and aero('arc_aero')) or
+		earth_tyrant() == AccessibilityLevel.SequenceBreak or
+		defeat_bergan() == AccessibilityLevel.SequenceBreak  or
+        cid2() == AccessibilityLevel.SequenceBreak or
+        aero('bal_aero') then 
+			return AccessibilityLevel.SequenceBreak
+	end
 end
 
 function hunt_club_start()
-    return tchita_uplands() and Tracker:ProviderCountForCode('shelled_trophy') > 0 and scaled_difficulty(6)
+    if tchita_uplands() == AccessibilityLevel.Normal and Tracker:ProviderCountForCode('shelled_trophy') > 0 and scaled_difficulty(6) then
+		return AccessibilityLevel.Normal
+	end
+	if tchita_uplands() == AccessibilityLevel.SequenceBreak and Tracker:ProviderCountForCode('shelled_trophy') > 0 then
+		return AccessibilityLevel.SequenceBreak
+	end
 end
 
 function defeat_vossler()
@@ -111,21 +128,21 @@ function dawn_shard()  -- Why is this a function?
 end
 
 function archades()
-    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace() == AccessibilityLevel.SequenceBreak then
-		return AccessibilityLevel.SequenceBreak
-	end
-    if aero('arc_aero') or (Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace()) then
+    if aero('arc_aero') or (Tracker:ProviderCountForCode('soul_ward_key') > 0 and sochen_cave_palace() == AccessibilityLevel.Normal) then
         return AccessibilityLevel.Normal
     end
+    if sochen_cave_palace() == AccessibilityLevel.SequenceBreak then
+		return AccessibilityLevel.SequenceBreak
+	end
 end
 
 function sochen_cave_palace()
-    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and tchita_uplands() == AccessibilityLevel.SequenceBreak then
+    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and (tchita_uplands() == AccessibilityLevel.Normal or aero('arc_aero')) and scaled_difficulty(4) then
+        return AccessibilityLevel.Normal 
+    end
+    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and (tchita_uplands() == AccessibilityLevel.SequenceBreak or aero('arc_aero')) then
 		return AccessibilityLevel.SequenceBreak
 	end
-    if Tracker:ProviderCountForCode('soul_ward_key') > 0 and (tchita_uplands() or archades()) then
-        return AccessibilityLevel.Normal
-    end
 end
 
 function draklor_laboratory()
@@ -159,7 +176,13 @@ function cid2()
     local stoneCount = Tracker:ProviderCountForCode('goddess_magicite') + Tracker:ProviderCountForCode('nethicite') +
         Tracker:ProviderCountForCode('dawn_shard')
 
-    return swordCount >= 1 and stoneCount >= 2 and has_n_system_access_keys(2) and has_n_black_orbs(3)
+    if swordCount >= 1 and stoneCount >= 2 and has_n_system_access_keys(2) and has_n_black_orbs(3) then
+	    if scaled_difficulty(7) then
+            return AccessibilityLevel.Normal
+        else
+            return AccessibilityLevel.SequenceBreak
+        end
+    end
 end
 
 function defeat_cid()

--- a/scripts/logic/logic.lua
+++ b/scripts/logic/logic.lua
@@ -159,7 +159,7 @@ function cid2()
     local stoneCount = Tracker:ProviderCountForCode('goddess_magicite') + Tracker:ProviderCountForCode('nethicite') +
         Tracker:ProviderCountForCode('dawn_shard')
 
-    return swordCount >= 1 and stoneCount >= 2
+    return swordCount >= 1 and stoneCount >= 2 and has_n_system_access_keys(2)
 end
 
 function defeat_cid()


### PR DESCRIPTION
Fixed cid2 function missing SAK and black orb count checks
Updated functions to check for and return `AccessibilityLevel.Normal` first
Added `AccessibilityLevel.SequenceBreak` returns to various functions
Updated functions and locations to handle `AccessibilityLevel.SequenceBreak`
Removed aero|bal_aero access rule from Hunt 34: Rocktoise as it is covered by the region rule and was missing $
Added $aero|bal_aero access rule to Balfonheim region