### PR TITLE
Hunt Club lua update

### DIFF
--- a/scripts/logic/huntclub.lua
+++ b/scripts/logic/huntclub.lua
@@ -28,8 +28,7 @@ TROPHY_RARES = {
     'bluesang',
     'aspidochelon',
     'abelisk',
-    'avenger',
-    'thalassinon'
+    'avenger'
 }
 
 function hunt_club_kills(n)


### PR DESCRIPTION
Removes Thalassinon since it's not counted for Hunt Club Owner as a defeated Trophy Rare Game.