### PR TITLE
Updated Defeat Omega Mark XII access rules

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -4772,7 +4772,7 @@
           {
             "name": "Defeat Omega Mark XII",
             "access_rules": [
-              "[$scaled_difficulty|8]"
+              "[$scaled_difficulty|8],yiazmat"
             ],
             "visibility_rules": [
               "place_clan_boss"

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -4772,7 +4772,7 @@
           {
             "name": "Defeat Omega Mark XII",
             "access_rules": [
-              "[$scaled_difficulty|8],yiazmat"
+              "[$scaled_difficulty|8],yiazmat_accepted"
             ],
             "visibility_rules": [
               "place_clan_boss"


### PR DESCRIPTION
Updated Defeat Omega Mark XII access rules to include Yiazmat requirement as it is dormant until Yiazmat Hunt accepted